### PR TITLE
ci: 🎡 updated configurations in .circleci/config.yml file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,10 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      # - image: circleci/node:7.10
+      - image: circleci/node:10.0.0 # for the CircleCI "Convenience" image
+      # - image: node:10.0.0 # for the Docker Library image
+
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images


### PR DESCRIPTION
This commit will updated the node version from 7 to 10 in the circleci
to enable successfully build due the failure of dot operator not be
applicable in the version of the node specified in the
.circleci/config.yml